### PR TITLE
remove reverend in favor of path-to-regexp.compile

### DIFF
--- a/lib/fixturl.js
+++ b/lib/fixturl.js
@@ -8,9 +8,9 @@
 
 'use strict';
 
-var reverend  = require('reverend'),
-    URI       = require('URIjs'),
-    custArray = require('./util/array');
+var path2regexp = require('path-to-regexp'),
+    URI         = require('URIjs'),
+    custArray   = require('./util/array');
 
 module.exports = function (/* String */ path, /* Object */ config) {
 
@@ -35,7 +35,7 @@ module.exports = function (/* String */ path, /* Object */ config) {
         query  = Array.isArray(query)  ? query  : [query];
 
         params.forEach(function (param) {
-            var url = reverend(path, param);
+            var url = path2regexp.compile(path)(param);
             query.forEach(function (qry) {
                 fixtures.push(URI(url).query(qry).toString());
             });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "URIjs": "^1.13.2",
     "es6-shim": "^0.14.0",
-    "reverend": "^0.3.0"
+    "path-to-regexp": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
[Path-to-regexp](https://github.com/pillarjs/path-to-regexp), which powers [Reverend](https://github.com/krakenjs/reverend), has recently added the [ability to reverse routes](https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp), rendering `Reverend` unnecessary. As such, `Reverend` is in the process of being deprecated.

The sole differences between the implementation in `Reverend` and that of `path-to-regexp` is a bit of duck-typing to prevent throws. This small amount of duck-typing can be seen in the [shim](http://github.com/krakenjs/reverend/blob/shim/index.js) branch.
